### PR TITLE
Add dark theme and duplicate task validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ Este proyecto es un gestor de tareas sencillo desarrollado con HTML, CSS y JavaS
 2. Abre el archivo `index.html` con un navegador web moderno. No se requieren dependencias adicionales.
 3. Empieza a agregar, completar o borrar tareas según lo necesites.
 
+## Características adicionales
+
+- Validación para evitar tareas duplicadas.
+- Soporte de tema oscuro con persistencia y un botón para alternar entre modo claro y oscuro.
+

--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
 </head>
 <body>
     <div class="container">
-        <h1>Gestor de Tareas</h1>
+        <div class="header">
+            <h1>Gestor de Tareas</h1>
+            <button id="theme-toggle" aria-label="Cambiar tema">🌙</button>
+        </div>
         <div class="task-counter">
             <p>Tareas pendientes: <span id="pending-tasks">0</span></p>
         </div>

--- a/script.js
+++ b/script.js
@@ -51,11 +51,35 @@ document.addEventListener('DOMContentLoaded', () => {
     const addTaskBtn = document.getElementById('add-task');
     const taskInput = document.getElementById('task-input');
     const taskList = document.getElementById('task-list');
+    const themeToggle = document.getElementById('theme-toggle');
+
+    function loadTheme() {
+        return localStorage.getItem('theme') || 'light';
+    }
+
+    function applyTheme(theme) {
+        document.body.classList.toggle('dark-theme', theme === 'dark');
+        themeToggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+    }
+
+    themeToggle.addEventListener('click', () => {
+        const current = loadTheme();
+        const next = current === 'light' ? 'dark' : 'light';
+        localStorage.setItem('theme', next);
+        applyTheme(next);
+    });
+
+    applyTheme(loadTheme());
 
     function handleAddTask() {
         const text = taskInput.value.trim();
         if (text) {
             const tasks = loadTasks();
+            const exists = tasks.some(task => task.text.toLowerCase() === text.toLowerCase());
+            if (exists) {
+                alert('La tarea ya existe');
+                return;
+            }
             tasks.push({ text, completed: false });
             saveTasks(tasks);
             renderTasks();

--- a/styles.css
+++ b/styles.css
@@ -4,31 +4,72 @@
     box-sizing: border-box;
 }
 
+:root {
+    --bg-color: #f0f2f5;
+    --container-bg: white;
+    --text-color: #2c3e50;
+    --secondary-text-color: #34495e;
+    --input-border-color: #ddd;
+    --primary-color: #3498db;
+    --primary-color-hover: #2980b9;
+    --task-item-border: #eee;
+    --task-item-hover-bg: #f8f9fa;
+    --completed-bg: #f8f9fa;
+    --completed-text: #888;
+    --delete-color: #e74c3c;
+    --delete-hover: #c0392b;
+}
+
+.dark-theme {
+    --bg-color: #121212;
+    --container-bg: #1e1e1e;
+    --text-color: #f5f5f5;
+    --secondary-text-color: #dddddd;
+    --input-border-color: #555;
+    --task-item-border: #333;
+    --task-item-hover-bg: #2c2c2c;
+    --completed-bg: #2c2c2c;
+}
+
 body {
     font-family: Arial, sans-serif;
-    background-color: #f0f2f5;
+    background-color: var(--bg-color);
+    color: var(--text-color);
     padding: 20px;
 }
 
 .container {
     max-width: 600px;
     margin: 0 auto;
-    background-color: white;
+    background-color: var(--container-bg);
     padding: 20px;
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
-h1 {
-    text-align: center;
-    color: #2c3e50;
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     margin-bottom: 20px;
+}
+
+h1 {
+    color: var(--text-color);
+}
+
+#theme-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 20px;
+    color: var(--text-color);
 }
 
 .task-counter {
     text-align: center;
     margin-bottom: 20px;
-    color: #34495e;
+    color: var(--secondary-text-color);
 }
 
 .task-form {
@@ -40,14 +81,16 @@ h1 {
 #task-input {
     flex: 1;
     padding: 10px;
-    border: 1px solid #ddd;
+    border: 1px solid var(--input-border-color);
     border-radius: 4px;
     font-size: 16px;
+    background-color: var(--container-bg);
+    color: var(--text-color);
 }
 
 #add-task {
     padding: 10px 20px;
-    background-color: #3498db;
+    background-color: var(--primary-color);
     color: white;
     border: none;
     border-radius: 4px;
@@ -57,7 +100,7 @@ h1 {
 }
 
 #add-task:hover {
-    background-color: #2980b9;
+    background-color: var(--primary-color-hover);
 }
 
 .task-list {
@@ -68,18 +111,18 @@ h1 {
     display: flex;
     align-items: center;
     padding: 10px;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid var(--task-item-border);
     transition: background-color 0.3s;
 }
 
 .task-item.completed {
-    background-color: #f8f9fa;
+    background-color: var(--completed-bg);
     text-decoration: line-through;
-    color: #888;
+    color: var(--completed-text);
 }
 
 .task-item:hover {
-    background-color: #f8f9fa;
+    background-color: var(--task-item-hover-bg);
 }
 
 .task-checkbox {
@@ -91,7 +134,7 @@ h1 {
 }
 
 .delete-btn {
-    color: #e74c3c;
+    color: var(--delete-color);
     border: none;
     background: none;
     cursor: pointer;
@@ -99,5 +142,5 @@ h1 {
 }
 
 .delete-btn:hover {
-    color: #c0392b;
+    color: var(--delete-hover);
 }


### PR DESCRIPTION
## Summary
- prevent duplicate tasks when adding new ones
- implement theme toggle with dark mode support
- update styling to support light/dark themes
- document new features

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68413990aba0832598d8cfc03998fe58